### PR TITLE
Dates will be correctly updated.

### DIFF
--- a/lib/module.coffee
+++ b/lib/module.coffee
@@ -76,7 +76,7 @@
   # for example, `{id: {name: 'Jon'}}` will be overwritten by `{id: {name: {first: 'Jon'}}}`
   deepExtendObject = (first, second) ->
     for own prop of second
-      if isObject(first[prop]) && _.has(first, prop)
+      if isObject(first[prop]) && _.has(first, prop) && !_.isDate(first[prop])
         deepExtendObject(first[prop], second[prop])
       else
         first[prop] = second[prop]


### PR DESCRIPTION
Background: I have an input of type date and had problems with updating the field value (I often got a year of 2 instead of the desired 2014)
I was able to track it down to the deepExtendExtend function which wasn't updating the changed object properly. 
The DeepExtendObject function was not updating date fields because the typeof a input field of type date is an object and then the function went down it's recursion.