### PR TITLE
Highlighted simple form value retrieval in Readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,9 @@ The **action function** runs when the form is submitted. It takes three params, 
   * If you passed in initial data, this contains an object with only the fields that have changed.
     If you didn't, this is `undefined`.
   * This is useful for figuring out what fields to use in an update query.
-
-Also, all validated form values are available with no extra work from `this`:
+  
+##### Retrieve Form Values with `this`
+All validated form values are available with no extra work:
 
 ```javascript
 // Inside the action function...


### PR DESCRIPTION
I thought the feature deserved to stand out more in the documentation.  I noticed that `this` had all the form values only after checking it out in the console.  I thought the documentation was suggesting to use `els` even after I happened to find the values in `this`.